### PR TITLE
Automate docs list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- feat: documentation sidebar auto-generates from markdown files

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,65 +1,9 @@
-"use client";
-import React, { useState } from "react";
-import { Card, CardContent } from "@/components/ui/card";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Separator } from "@/components/ui/separator";
-import { DocMarkdown } from "@/components/docs/doc-markdown";
+import { getDocs } from '@/lib/docs';
+import dynamic from 'next/dynamic';
 
-const DOCS = [
-  { title: "Key Features", file: "key-features.md" },
-  { title: "Future SDK Integrations", file: "future-integrations.md" },
-  { title: "Getting Started", file: "getting-started.md" },
-  { title: "User Guide", file: "user-guide.md" },
-  { title: "Developer Notes", file: "dev-notes.md" },
-  { title: "Project Tasks & Roadmap", file: "tasks.md" },
-  { title: "Example Use Cases", file: "use-cases.md" },
-  { title: "Contributing", file: "contributing.md" },
-  { title: "License", file: "license.md" },
-];
+const DocsBrowser = dynamic(() => import('@/components/docs/docs-browser.client'));
 
-export default function DocsIndexPage() {
-  const [selected, setSelected] = useState(DOCS[0].file);
-  return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100 flex">
-      {/* Sidebar (no shadcn Sidebar, just a styled div) */}
-      <div className="w-64 bg-zinc-900 border-r border-zinc-800 flex flex-col py-8 px-0 min-h-screen">
-        <div className="px-6 pb-4">
-          <h2 className="text-lg font-bold text-zinc-200 tracking-tight">
-            Documentation
-          </h2>
-        </div>
-        <Separator className="bg-zinc-800" />
-        <ScrollArea className="flex-1 px-2">
-          <nav>
-            <ul className="space-y-1 mt-2">
-              {DOCS.map((doc) => (
-                <li key={doc.file}>
-                  <button
-                    onClick={() => setSelected(doc.file)}
-                    className={`w-full text-left px-4 py-2 rounded transition-colors text-sm font-medium ${selected === doc.file ? "bg-zinc-800 text-white" : "text-zinc-400 hover:bg-zinc-800 hover:text-white"}`}
-                  >
-                    {doc.title}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </nav>
-        </ScrollArea>
-      </div>
-      {/* Main Content */}
-      <main className="flex-1 flex flex-col items-center py-10 px-2 md:px-0">
-        <Card className="w-full max-w-3xl bg-zinc-900 border-zinc-800 shadow-xl">
-          <CardContent className="p-8">
-            <h1 className="text-3xl font-bold mb-6 text-zinc-100 text-center tracking-tight">
-              Kapped Documentation
-            </h1>
-            <Separator className="mb-6 bg-zinc-800" />
-            <div className="bg-zinc-950 rounded-lg p-6 min-h-[400px] border border-zinc-800">
-              <DocMarkdown file={selected} />
-            </div>
-          </CardContent>
-        </Card>
-      </main>
-    </div>
-  );
+export default async function DocsIndexPage() {
+  const docs = await getDocs();
+  return <DocsBrowser docs={docs} />;
 }

--- a/components/docs/docs-browser.client.tsx
+++ b/components/docs/docs-browser.client.tsx
@@ -1,0 +1,60 @@
+"use client";
+import React, { useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { DocMarkdown } from "@/components/docs/doc-markdown";
+import type { getDocs } from "@/lib/docs";
+
+export interface DocsBrowserProps {
+  /** List of docs returned from `getDocs`. */
+  docs: Awaited<ReturnType<typeof getDocs>>;
+}
+
+/**
+ * Interactive documentation browser. Displays a sidebar with links and renders
+ * the selected markdown file using {@link DocMarkdown}.
+ */
+export default function DocsBrowser({ docs }: DocsBrowserProps) {
+  const [selected, setSelected] = useState(docs[0]?.file ?? "");
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100 flex">
+      <div className="w-64 bg-zinc-900 border-r border-zinc-800 flex flex-col py-8 px-0 min-h-screen">
+        <div className="px-6 pb-4">
+          <h2 className="text-lg font-bold text-zinc-200 tracking-tight">Documentation</h2>
+        </div>
+        <Separator className="bg-zinc-800" />
+        <ScrollArea className="flex-1 px-2">
+          <nav aria-label="Documentation">
+            <ul className="space-y-1 mt-2">
+              {docs.map((doc) => (
+                <li key={doc.file}>
+                  <button
+                    onClick={() => setSelected(doc.file)}
+                    className={`w-full text-left px-4 py-2 rounded transition-colors text-sm font-medium ${selected === doc.file ? "bg-zinc-800 text-white" : "text-zinc-400 hover:bg-zinc-800 hover:text-white"}`}
+                    aria-current={selected === doc.file ? "page" : undefined}
+                  >
+                    {doc.title}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </ScrollArea>
+      </div>
+      <main className="flex-1 flex flex-col items-center py-10 px-2 md:px-0">
+        <Card className="w-full max-w-3xl bg-zinc-900 border-zinc-800 shadow-xl">
+          <CardContent className="p-8">
+            <h1 className="text-3xl font-bold mb-6 text-zinc-100 text-center tracking-tight">
+              Kapped Documentation
+            </h1>
+            <Separator className="mb-6 bg-zinc-800" />
+            <div className="bg-zinc-950 rounded-lg p-6 min-h-[400px] border border-zinc-800">
+              <DocMarkdown file={selected} />
+            </div>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -44,7 +44,8 @@ Getting started is easy and exciting! Just follow these steps:
 
 - `components/` — All React components, organized by feature and type.
 - `app/` — Next.js app directory, including pages and layouts.
-- `docs/` — Project documentation for users and developers.
+- `docs/` — Project documentation for users and developers. Any new markdown file
+  added here automatically appears in the documentation sidebar via `getDocs()`.
 - `hooks/` — Custom React hooks.
 - `lib/` — Utility functions and shared logic.
 - `public/` — Static assets such as images and icons.

--- a/lib/docs.test.ts
+++ b/lib/docs.test.ts
@@ -1,0 +1,21 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { getDocs } from './docs';
+
+describe('getDocs', () => {
+  const temp = path.join(process.cwd(), 'docs/test-temp.md');
+
+  beforeAll(async () => {
+    await fs.writeFile(temp, '# Temp Doc');
+  });
+
+  afterAll(async () => {
+    await fs.unlink(temp);
+  });
+
+  it('includes newly created markdown files', async () => {
+    const docs = await getDocs();
+    const names = docs.map((d) => d.file);
+    expect(names).toContain('test-temp.md');
+  });
+});

--- a/lib/docs.ts
+++ b/lib/docs.ts
@@ -1,0 +1,28 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+/**
+ * Reads all markdown files from the local `docs` directory. The first line of
+ * each file is used as the display title. If a file does not begin with a
+ * markdown heading, the file name (minus the `.md` extension) is used instead.
+ *
+ * @returns Promise resolving to a list of available docs.
+ *
+ * @example
+ * const docs = await getDocs();
+ * // [{ title: 'Getting Started', file: 'getting-started.md' }, ...]
+ */
+export async function getDocs(): Promise<{ title: string; file: string }[]> {
+  const docsDir = path.join(process.cwd(), 'docs');
+  const files = await fs.readdir(docsDir);
+  const mdFiles = files.filter((f) => f.endsWith('.md'));
+  const docs = await Promise.all(
+    mdFiles.map(async (file) => {
+      const content = await fs.readFile(path.join(docsDir, file), 'utf8');
+      const firstLine = content.split('\n')[0];
+      const title = firstLine.replace(/^#\s*/, '').trim() || file.replace(/\.md$/, '');
+      return { title, file };
+    })
+  );
+  return docs;
+}


### PR DESCRIPTION
## Summary
- build docs helper to read titles from markdown
- render docs page as a server component and delegate to a small client component
- describe auto sidebar behaviour in dev notes
- add changelog entry
- test docs helper

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`

------
https://chatgpt.com/codex/tasks/task_e_684626dac3908325a45dd919d7ac27da