### PR TITLE
Fix docs-browser import paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,5 @@
 - refactor component hierarchy into atoms, molecules and organisms
 
 - feat: documentation sidebar auto-generates from markdown files
+- fix: correct docs-browser imports for new atom paths
 

--- a/components/docs/docs-browser.client.tsx
+++ b/components/docs/docs-browser.client.tsx
@@ -1,9 +1,9 @@
 "use client";
 import React, { useState } from "react";
-import { Card, CardContent } from "@/components/ui/card";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Separator } from "@/components/ui/separator";
-import { DocMarkdown } from "@/components/docs/doc-markdown";
+import { Card, CardContent } from "@/components/atoms/card";
+import { ScrollArea } from "@/components/atoms/scroll-area";
+import { Separator } from "@/components/atoms/separator";
+import { DocMarkdown } from "@/components/molecules/doc-markdown";
 import type { getDocs } from "@/lib/docs";
 
 export interface DocsBrowserProps {


### PR DESCRIPTION
## Summary
- fix incorrect import paths in docs-browser
- update changelog

## Testing
- `pnpm test` *(fails: jest not found)*
- `pnpm lint` *(fails: cannot find ESLint package)*
- `pnpm typecheck` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462d627d408325ba5d232329f3a710