### PR TITLE
Add sandbox-vite scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- feat: add Vite sandbox scaffolding
 
 - migrate test suite to Vitest
 

--- a/sandbox-vite/index.html
+++ b/sandbox-vite/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite Sandbox</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/sandbox-vite/package.json
+++ b/sandbox-vite/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sandbox-vite",
+  "private": true,
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build"
+  }
+}

--- a/sandbox-vite/src/main.ts
+++ b/sandbox-vite/src/main.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+function App() {
+  return React.createElement('div', null, 'Hello Sandbox');
+}
+
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  ReactDOM.createRoot(rootElement).render(
+    React.createElement(React.StrictMode, null, React.createElement(App))
+  );
+}

--- a/sandbox-vite/vite.config.ts
+++ b/sandbox-vite/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add `sandbox-vite` with minimal Vite + React setup
- note new sandbox in CHANGELOG

## Testing
- `pnpm test` *(fails: Failed to resolve imports)*
- `pnpm lint` *(fails: lint errors in repo)*
- `pnpm typecheck` *(fails: TS5090 path errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846380e017c8325b7e104a7992c35b7