### PR TITLE
ci: add workflow for sandbox build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm lint
+      - run: pnpm typecheck
+      - run: pnpm test
+      - run: pnpm --prefix sandbox-vite install
+      - run: pnpm --prefix sandbox-vite build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sandbox-vite-dist
+          path: sandbox-vite/dist
+          if-no-files-found: error
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- chore: add CI workflow for sandbox-vite build
 
 - migrate test suite to Vitest
 


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to run tests, lint, typecheck
- build sandbox-vite and upload its dist as an artifact
- document workflow addition in CHANGELOG

## Testing
- `pnpm test` *(fails: Failed Suites 4, Failed Tests 1)*
- `pnpm lint` *(fails with lint errors)*
- `pnpm typecheck` *(fails with TS5090 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68463954c7d88325b35868fdbace1e05