### PR TITLE
Update sandbox script and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@
 - feat: documentation sidebar auto-generates from markdown files
 
 - fix: correct docs-browser imports for new atom paths
+- chore: update sandbox script to run Next.js on 3001 and Vite on 5173
 
 

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -36,7 +36,13 @@ Getting started is easy and exciting! Just follow these steps:
    ```powershell
    npm run dev
    ```
-4. **Environment Variables:**
+4. **Start the Sandbox Environment:**
+   Run Next.js and Vite together:
+   ```bash
+   pnpm sandbox
+   ```
+   Next.js listens on [http://localhost:3001](http://localhost:3001) and Vite on [http://localhost:5173](http://localhost:5173).
+5. **Environment Variables:**
    - Create a `.env.local` file in the root directory for any required environment variables.
    - Refer to `.env.example` if available.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,13 @@ Welcome to Kapped! We’re thrilled to have you join our community of innovators
    ```powershell
    npm run dev
    ```
-4. **Access the Platform**
+4. **Optional: Run the Sandbox**
+   Launch Next.js and Vite together:
+   ```bash
+   pnpm sandbox
+   ```
+   Next.js is available at `http://localhost:3001` and Vite at `http://localhost:5173`.
+5. **Access the Platform**
    Open your favorite web browser and navigate to `http://localhost:3000`.
 
 That’s it! You’re ready to explore, create, and innovate with Kapped. For more detailed instructions and advanced setup options, check out our [User Guide](user-guide.md) and [Developer Notes](dev-notes.md). Happy building!

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf ./node_modules ./package-lock.json ./.next",
     "update": "npm update",
     "clear:prompt": "npx tsx scripts/clear-prompt.ts",
-    "sandbox": "next dev -p 3001 && cd ../sandbox-vite && vite dev",
+    "sandbox": "concurrently \"next dev -p 3001\" \"pnpm --prefix ./sandbox-vite dev\"",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- update `sandbox` script to use concurrently
- document Next.js and Vite ports in dev notes and getting started guide
- note sandbox script change in CHANGELOG

## Testing
- `pnpm test` *(fails: Failed Suites 4)*
- `pnpm lint` *(fails: 8 errors, 1 warning)*
- `pnpm typecheck` *(fails: TS5090 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846394f7cfc832585342193c23d5016