### PR TITLE
Fix header and sidebar tests

### DIFF
--- a/__tests__/header/header-center-slot.test.tsx
+++ b/__tests__/header/header-center-slot.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import HeaderCenterSlot from '@/components/header/header-center-slot';
+import HeaderCenterSlot from '@/components/molecules/header-center-slot';
 
 describe('HeaderCenterSlot', () => {
   it('renders three icons', () => {

--- a/__tests__/header/header-left-slot.test.tsx
+++ b/__tests__/header/header-left-slot.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import HeaderLeftSlot from '@/components/header/header-left-slot';
+import HeaderLeftSlot from '@/components/molecules/header-left-slot';
 
 describe('HeaderLeftSlot', () => {
   it('toggles dropdown open and close', async () => {

--- a/__tests__/header/header-right-slot.test.tsx
+++ b/__tests__/header/header-right-slot.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import HeaderRightSlot from '@/components/header/header-right-slot';
+import HeaderRightSlot from '@/components/molecules/header-right-slot';
 
 describe('HeaderRightSlot', () => {
   it('shows docs link', () => {

--- a/__tests__/integration/docs-page.test.tsx
+++ b/__tests__/integration/docs-page.test.tsx
@@ -5,14 +5,22 @@ import { createSandbox } from '@genr8/testing-sandbox';
 
 vi.mock('@genr8/testing-sandbox', () => ({
   createSandbox: vi.fn(() => ({
-    load: vi.fn(async () => ({ container: render(<DocsIndexPage />).container })),
+    load: vi.fn(async () => {
+      const element = await DocsIndexPage();
+      return { container: render(element).container };
+    }),
     close: vi.fn(),
   })),
 }));
 
+interface Sandbox {
+  load: (path: string) => Promise<{ container: HTMLElement }>;
+  close: () => void;
+}
+
 describe('Docs integration', () => {
   it('renders markdown inside sandbox', async () => {
-    const sandbox = createSandbox() as any;
+    const sandbox = createSandbox() as unknown as Sandbox;
     const { container } = await sandbox.load('/docs');
     expect(container.querySelector('.prose')).toBeInTheDocument();
   });

--- a/__tests__/sidebar/sidebar-modules.test.tsx
+++ b/__tests__/sidebar/sidebar-modules.test.tsx
@@ -9,7 +9,7 @@ import {
   SidebarMenuItem,
   SidebarMenuButton,
   useSidebar,
-} from '@/components/ui/sidebar';
+} from '@/components/organisms/sidebar';
 
 function Wrapper() {
   return (

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,14 +1,6 @@
-"use client";
-import React, { useState } from "react";
-import { Card, CardContent } from "@/components/atoms/card";
-import { ScrollArea } from "@/components/atoms/scroll-area";
-import { Separator } from "@/components/atoms/separator";
-import { DocMarkdown } from "@/components/molecules/doc-markdown";
+import React from "react";
 import { getDocs } from '@/lib/docs';
-import dynamic from 'next/dynamic';
-
-
-const DocsBrowser = dynamic(() => import('@/components/docs/docs-browser.client'));
+import DocsBrowser from '@/components/docs/docs-browser.client';
 
 export default async function DocsIndexPage() {
   const docs = await getDocs();

--- a/components/organisms/sidebar/sidebar-panel.tsx
+++ b/components/organisms/sidebar/sidebar-panel.tsx
@@ -5,6 +5,8 @@ import { cn } from "@/lib/utils";
 import { useSidebar } from "./sidebar-provider";
 import { Button } from "@/components/atoms/button";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/atoms/sheet";
+
+const SIDEBAR_WIDTH_MOBILE = "18rem";
 /**
  * Sidebar container with responsive variants.
  */

--- a/components/organisms/sidebar/sidebar-provider.tsx
+++ b/components/organisms/sidebar/sidebar-provider.tsx
@@ -8,7 +8,6 @@ import { TooltipProvider } from "@/components/atoms/tooltip";
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "16rem";
-const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "types": ["vitest/globals", "@testing-library/jest-dom"],
     "paths": {
       "@/*": [


### PR DESCRIPTION
## Summary
- update header tests to import header slots from `molecules`
- update sidebar test to import new sidebar module
- remove client directive and dynamic import from docs page
- mock docs sandbox correctly
- add missing constant and clean up sidebar provider
- set `baseUrl` for path aliases in tsconfig

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68463936c89c83259e6fbf04f3ee3091