### PR TITLE
Fix docs page to server component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@
 - feat: documentation sidebar auto-generates from markdown files
 
 - fix: correct docs-browser imports for new atom paths
+- fix: convert docs page to server component and clean up unused imports
 
 

--- a/__tests__/header/header-center-slot.test.tsx
+++ b/__tests__/header/header-center-slot.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import HeaderCenterSlot from '@/components/header/header-center-slot';
+import HeaderCenterSlot from '@/components/molecules/header-center-slot';
 
 describe('HeaderCenterSlot', () => {
   it('renders three icons', () => {

--- a/__tests__/header/header-left-slot.test.tsx
+++ b/__tests__/header/header-left-slot.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import HeaderLeftSlot from '@/components/header/header-left-slot';
+import HeaderLeftSlot from '@/components/molecules/header-left-slot';
 
 describe('HeaderLeftSlot', () => {
   it('toggles dropdown open and close', async () => {

--- a/__tests__/header/header-right-slot.test.tsx
+++ b/__tests__/header/header-right-slot.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import HeaderRightSlot from '@/components/header/header-right-slot';
+import HeaderRightSlot from '@/components/molecules/header-right-slot';
 
 describe('HeaderRightSlot', () => {
   it('shows docs link', () => {

--- a/__tests__/integration/docs-page.test.tsx
+++ b/__tests__/integration/docs-page.test.tsx
@@ -1,19 +1,19 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import DocsIndexPage from '@/app/docs/page';
 import { createSandbox } from '@genr8/testing-sandbox';
 
 vi.mock('@genr8/testing-sandbox', () => ({
   createSandbox: vi.fn(() => ({
-    load: vi.fn(async () => ({ container: render(<DocsIndexPage />).container })),
+    load: vi.fn(async () => ({ container: render(await DocsIndexPage()).container })),
     close: vi.fn(),
   })),
 }));
 
 describe('Docs integration', () => {
   it('renders markdown inside sandbox', async () => {
-    const sandbox = createSandbox() as any;
+    const sandbox = createSandbox();
     const { container } = await sandbox.load('/docs');
-    expect(container.querySelector('.prose')).toBeInTheDocument();
+    await waitFor(() => expect(container.querySelector('.prose')).toBeInTheDocument());
   });
 });

--- a/__tests__/sidebar/sidebar-modules.test.tsx
+++ b/__tests__/sidebar/sidebar-modules.test.tsx
@@ -9,7 +9,7 @@ import {
   SidebarMenuItem,
   SidebarMenuButton,
   useSidebar,
-} from '@/components/ui/sidebar';
+} from '@organisms/sidebar';
 
 function Wrapper() {
   return (

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,9 +1,3 @@
-"use client";
-import React, { useState } from "react";
-import { Card, CardContent } from "@/components/atoms/card";
-import { ScrollArea } from "@/components/atoms/scroll-area";
-import { Separator } from "@/components/atoms/separator";
-import { DocMarkdown } from "@/components/molecules/doc-markdown";
 import { getDocs } from '@/lib/docs';
 import dynamic from 'next/dynamic';
 

--- a/components/organisms/sidebar/sidebar-panel.tsx
+++ b/components/organisms/sidebar/sidebar-panel.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { useSidebar } from "./sidebar-provider";
 import { Button } from "@/components/atoms/button";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/atoms/sheet";
+const SIDEBAR_WIDTH_MOBILE = "18rem";
 /**
  * Sidebar container with responsive variants.
  */

--- a/components/organisms/sidebar/sidebar-provider.tsx
+++ b/components/organisms/sidebar/sidebar-provider.tsx
@@ -8,7 +8,6 @@ import { TooltipProvider } from "@/components/atoms/tooltip";
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "16rem";
-const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
       }
     ],
     "types": ["vitest/globals", "@testing-library/jest-dom"],
+    "baseUrl": ".",
     "paths": {
       "@/*": [
         "./*"
@@ -35,6 +36,9 @@
       ],
       "@organisms/*": [
         "components/organisms/*"
+      ],
+      "@genr8/testing-sandbox": [
+        "__mocks__/genr8-testing-sandbox.d.ts"
       ]
     }
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./', import.meta.url)),
       '@genr8/testing-sandbox': fileURLToPath(new URL('./__mocks__/genr8-testing-sandbox.ts', import.meta.url)),
+      '@organisms': fileURLToPath(new URL('./components/organisms', import.meta.url)),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- convert docs page to server component
- adjust tests to new paths and server component behavior
- update tsconfig paths and vitest aliases
- add missing constant for mobile sidebar width

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684639269afc83258090c58fae0cc8e7