### PR TITLE
Serve Vite sandbox build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@
 - feat: documentation sidebar auto-generates from markdown files
 
 - fix: correct docs-browser imports for new atom paths
+- feat: serve sandbox build in production
 
 

--- a/__tests__/integration/sandbox-page.test.tsx
+++ b/__tests__/integration/sandbox-page.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react';
+import { vi } from 'vitest';
+import SandboxPage from '@/app/sandbox/page';
+import { createSandbox } from '@genr8/testing-sandbox';
+
+vi.mock('@genr8/testing-sandbox', () => ({
+  createSandbox: vi.fn(() => ({
+    load: vi.fn(async () => ({ container: render(<SandboxPage />).container })),
+    close: vi.fn(),
+  })),
+}));
+
+describe('Sandbox integration', () => {
+  it('uses built assets in production', async () => {
+    process.env.NODE_ENV = 'production';
+    const sandbox = createSandbox() as any;
+    const { container } = await sandbox.load('/sandbox');
+    const iframe = container.querySelector('iframe');
+    expect(iframe).toHaveAttribute('src', '/sandbox-vite/dist/index.html');
+  });
+});

--- a/__tests__/lib/sandbox-url.test.ts
+++ b/__tests__/lib/sandbox-url.test.ts
@@ -1,0 +1,24 @@
+import { getSandboxUrl } from '@/lib/sandbox-url';
+
+describe('getSandboxUrl', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it('returns local server url in development', () => {
+    process.env.NODE_ENV = 'development';
+    expect(getSandboxUrl()).toBe('http://localhost:5173');
+  });
+
+  it('returns dist path in production', () => {
+    process.env.NODE_ENV = 'production';
+    expect(getSandboxUrl()).toBe('/sandbox-vite/dist/index.html');
+  });
+
+  it('defaults to local server for unknown env', () => {
+    process.env.NODE_ENV = 'staging';
+    expect(getSandboxUrl()).toBe('http://localhost:5173');
+  });
+});

--- a/app/sandbox-vite/[...path]/route.ts
+++ b/app/sandbox-vite/[...path]/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { join } from 'path';
+import { readFile } from 'fs/promises';
+
+const baseDir = join(process.cwd(), 'sandbox-vite', 'dist');
+
+function getMimeType(filePath: string): string {
+  const ext = filePath.split('.').pop();
+  switch (ext) {
+    case 'html':
+      return 'text/html';
+    case 'js':
+      return 'text/javascript';
+    case 'css':
+      return 'text/css';
+    case 'json':
+      return 'application/json';
+    case 'png':
+      return 'image/png';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'svg':
+      return 'image/svg+xml';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+/**
+ * Serve files from the local `sandbox-vite/dist` directory.
+ *
+ * @param _req - Incoming request (unused).
+ * @param params - Optional path segments to the file within the dist directory.
+ * @returns `NextResponse` containing the file or a 404 response.
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { path?: string[] } }
+) {
+  const segments = params.path ?? ['index.html'];
+  const filePath = join(baseDir, ...segments);
+  if (!filePath.startsWith(baseDir)) {
+    return new NextResponse('Not Found', { status: 404 });
+  }
+  try {
+    const data = await readFile(filePath);
+    return new NextResponse(data, {
+      headers: { 'Content-Type': getMimeType(filePath) },
+    });
+  } catch {
+    return new NextResponse('Not Found', { status: 404 });
+  }
+}

--- a/app/sandbox/page.tsx
+++ b/app/sandbox/page.tsx
@@ -3,13 +3,18 @@ import HeaderLeftSlot from "@/components/molecules/header-left-slot";
 import HeaderCenterSlot from "@/components/molecules/header-center-slot";
 import HeaderRightSlot from "@/components/molecules/header-right-slot";
 import { SidebarProvider, Sidebar } from "@/components/organisms/sidebar";
+import { getSandboxUrl } from "@/lib/sandbox-url";
 import {
   ResizablePanelGroup,
   ResizablePanel,
   ResizableHandle,
 } from "@/components/atoms/resizable";
 
+/**
+ * Sandbox UI embedding the Vite application.
+ */
 export default function SandboxPage() {
+  const iframeSrc = getSandboxUrl();
   return (
     <div className="flex flex-col h-screen w-screen bg-zinc-950">
       <HeaderShell
@@ -38,7 +43,7 @@ export default function SandboxPage() {
             <div className="h-full w-full flex items-center justify-center">
               <iframe
                 title="Sandboxed Vite App"
-                src="http://localhost:5173" // Point to your Vite app
+                src={iframeSrc}
                 sandbox="allow-scripts allow-same-origin"
                 className="w-full h-full border-0 rounded-lg shadow-xl bg-zinc-950"
                 style={{ minHeight: "80vh" }}

--- a/lib/sandbox-url.ts
+++ b/lib/sandbox-url.ts
@@ -1,0 +1,17 @@
+/**
+ * Resolve the iframe URL for the sandbox application.
+ *
+ * The development environment loads the local Vite dev server.
+ * Production environments use the built static assets.
+ *
+ * @returns URL string used for the sandbox iframe.
+ *
+ * @example
+ * const url = getSandboxUrl();
+ * // "http://localhost:5173" on development
+ */
+export function getSandboxUrl(): string {
+  return process.env.NODE_ENV === 'production'
+    ? '/sandbox-vite/dist/index.html'
+    : 'http://localhost:5173';
+}


### PR DESCRIPTION
## Summary
- use `getSandboxUrl` to pick iframe URL
- expose static handler for `sandbox-vite/dist` assets
- test URL resolution logic and sandbox integration
- note feature in changelog

## Testing
- `pnpm test` *(fails: module resolution errors)*
- `pnpm lint` *(fails: lint errors in repository)*
- `pnpm typecheck` *(fails: TS5090 baseUrl errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846395129e48325a3c68e247c13f8e0