### PR TITLE
Switch sandbox script to npm

### DIFF
--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -39,7 +39,7 @@ Getting started is easy and exciting! Just follow these steps:
 4. **Start the Sandbox Environment:**
    Run Next.js and Vite together:
    ```bash
-   pnpm sandbox
+   npm run sandbox
    ```
    Next.js listens on [http://localhost:3001](http://localhost:3001) and Vite on [http://localhost:5173](http://localhost:5173).
 5. **Environment Variables:**
@@ -79,7 +79,7 @@ Kapped leverages the best modern web technologies:
 - Use **Vitest** with **React Testing Library** for fast and reliable feedback.
 - Run tests locally before pushing changes:
   ```bash
-  pnpm test && pnpm lint && pnpm typecheck
+  npm test && npm run lint && npm run typecheck
   ```
 
 ## Code Quality

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ Welcome to Kapped! We’re thrilled to have you join our community of innovators
 4. **Optional: Run the Sandbox**
    Launch Next.js and Vite together:
    ```bash
-   pnpm sandbox
+   npm run sandbox
    ```
    Next.js is available at `http://localhost:3001` and Vite at `http://localhost:5173`.
 5. **Access the Platform**

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf ./node_modules ./package-lock.json ./.next",
     "update": "npm update",
     "clear:prompt": "npx tsx scripts/clear-prompt.ts",
-    "sandbox": "concurrently \"next dev -p 3001\" \"pnpm --prefix ./sandbox-vite dev\"",
+    "sandbox": "concurrently \"next dev -p 3001\" \"npm --prefix ./sandbox-vite run dev\"",
     "typecheck": "tsc --noEmit",
     "setup:build": "npm run lint && npm run typecheck && npm run test && npm run build",
     "setup:dev": "npm run lint && npm run typecheck && npm run test && npm run dev",


### PR DESCRIPTION
## Summary
- standardize on npm for running the sandbox
- document npm sandbox usage in developer docs
- reference npm sandbox command in Getting Started guide

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npx zod-cli validate lib/templates.json` *(fails: package not found)*


------
https://chatgpt.com/codex/tasks/task_e_6846caf4d228832585784f8892d79f38