### PR TITLE
Add template registry with schema

### DIFF
--- a/lib/template-schema.json
+++ b/lib/template-schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "name", "entry", "port", "runtime", "dockerImage"],
+    "properties": {
+      "id": {"type": "string"},
+      "name": {"type": "string"},
+      "entry": {"type": "string"},
+      "port": {"type": "integer"},
+      "runtime": {"type": "string"},
+      "dockerImage": {"type": "string"},
+      "description": {"type": "string"},
+      "icon": {"type": "string"},
+      "features": {
+        "type": "array",
+        "items": {"type": "string"}
+      },
+      "version": {"type": "string"}
+    },
+    "additionalProperties": false
+  }
+}

--- a/lib/template-schema.ts
+++ b/lib/template-schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const templateSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  entry: z.string(),
+  port: z.number(),
+  runtime: z.string(),
+  dockerImage: z.string(),
+  description: z.string().optional(),
+  icon: z.string().optional(),
+  features: z.array(z.string()).optional(),
+  version: z.string().optional(),
+});
+
+export const templatesSchema = z.array(templateSchema);
+
+export type Template = z.infer<typeof templateSchema>;
+export type Templates = z.infer<typeof templatesSchema>;

--- a/lib/templates.json
+++ b/lib/templates.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "nextjs-developer",
+    "name": "Next.js Developer Capsule",
+    "entry": "app.ts",
+    "port": 3000,
+    "runtime": "nodejs",
+    "dockerImage": "e2b/nextjs:latest",
+    "features": ["typescript", "live reload"]
+  }
+]


### PR DESCRIPTION
## Summary
- add JSON schema for template definitions
- add templates.json registry with a sample entry
- expose typed schema via `template-schema.ts`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npx zod-cli validate lib/templates.json` *(fails: package not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846cb5f73c08325860ad2e371b3e80c