### PR TITLE
fix docs styling and loader

### DIFF
--- a/components/docs/doc-markdown.test.tsx
+++ b/components/docs/doc-markdown.test.tsx
@@ -25,6 +25,30 @@ describe("DocMarkdown", () => {
     vi.clearAllMocks(); // Reset mocks before each test
   });
 
+  it("shows a loading indicator while fetching", async () => {
+    let resolveFn: (value: Response) => void = () => {};
+    vi.mocked(global.fetch).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+
+    render(<DocMarkdown file="loading.md" />);
+
+    expect(
+      screen.getByText("Loading documentation...")
+    ).toBeInTheDocument();
+
+    resolveFn(new Response("# Hi"));
+    vi.mocked(marked.parse).mockResolvedValueOnce("<h1>Hi</h1>");
+    vi.mocked(DOMPurify.sanitize).mockReturnValueOnce("<h1>Hi</h1>");
+
+    await waitFor(() => {
+      expect(document.querySelector(".prose")?.innerHTML).toBe("<h1>Hi</h1>");
+    });
+  });
+
   it("renders markdown content successfully", async () => {
     const mockMarkdown = "# Hello World";
     const mockParsedHtml = "<h1>Hello World</h1>";
@@ -81,10 +105,9 @@ describe("DocMarkdown", () => {
     render(<DocMarkdown file="nonexistent.md" />);
 
     await waitFor(() => {
-      const errorMessage = screen.getByText("Error loading documentation.");
+      const errorMessage = screen.getByText("Failed to load documentation.");
       expect(errorMessage).toBeInTheDocument();
       expect(errorMessage.tagName.toLowerCase()).toBe("p");
-      expect(errorMessage.style.color).toBe("red");
     });
   });
 
@@ -106,8 +129,9 @@ describe("DocMarkdown", () => {
     render(<DocMarkdown file="missing.md" />);
 
     await waitFor(() => {
-      const errorMessage = screen.getByText("Error loading documentation.");
+      const errorMessage = screen.getByText("Failed to load documentation.");
       expect(errorMessage).toBeInTheDocument();
     });
   });
 });
+

--- a/components/docs/doc-markdown.tsx
+++ b/components/docs/doc-markdown.tsx
@@ -12,11 +12,21 @@ interface DocMarkdownProps {
  */
 export function DocMarkdown({ file }: DocMarkdownProps) {
   const [html, setHtml] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
   useEffect(() => {
-    if (!file) return;
+    if (!file) {
+      setHtml("");
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
     fetch(`/docs/${encodeURIComponent(file)}`)
       .then((res) => {
-        if (!res.ok) throw new Error("404");
+        if (!res.ok) throw new Error(String(res.status));
         return res.text();
       })
       .then(async (md: string) => {
@@ -25,9 +35,20 @@ export function DocMarkdown({ file }: DocMarkdownProps) {
         setHtml(sanitized);
       })
       .catch(() => {
-        setHtml('<p style="color:red">Error loading documentation.</p>');
+        setError("Failed to load documentation.");
+        setHtml("");
+      })
+      .finally(() => {
+        setLoading(false);
       });
   }, [file]);
+
+  if (loading) {
+    return <p className="text-muted">Loading documentation...</p>;
+  }
+  if (error) {
+    return <p className="text-red-500">{error}</p>;
+  }
 
   return (
     <div
@@ -36,3 +57,4 @@ export function DocMarkdown({ file }: DocMarkdownProps) {
     />
   );
 }
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "@babel/preset-typescript": "7.27.1",
         "@eslint/eslintrc": "3.0.0",
         "@tailwindcss/postcss": "4.1.8",
+        "@tailwindcss/typography": "0.5.16",
         "@testing-library/jest-dom": "6.6.3",
         "@testing-library/react": "16.3.0",
         "@testing-library/user-event": "14.6.1",
@@ -5595,6 +5596,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
@@ -7490,6 +7507,19 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/cssstyle": {
       "version": "4.4.0",
@@ -10390,10 +10420,24 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -11115,6 +11159,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -13081,6 +13139,13 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vaul": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "jsdom": "26.1.0",
     "rimraf": "6.0.1",
     "tailwindcss": "4.0.0",
+    "@tailwindcss/typography": "0.5.16",
     "tsx": "4.19.4",
     "tw-animate-css": "1.3.4",
     "typescript": "5.8.3",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './docs/**/*.md',
+  ],
+  plugins: [require('@tailwindcss/typography')],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind with typography plugin
- improve DocMarkdown with loading and error states
- expand tests for DocMarkdown loader

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npx zod-cli validate lib/templates.json` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a795edab48325a1d508ba1763e788