### PR TITLE
Fix placeholder typo and add test

### DIFF
--- a/__tests__/integration/sandbox-placeholder.test.tsx
+++ b/__tests__/integration/sandbox-placeholder.test.tsx
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import { vi } from "vitest";
+import SandboxPage from "@/app/projects/page";
+import { createSandbox } from "@genr8/testing-sandbox";
+
+vi.mock("@genr8/testing-sandbox", () => ({
+  createSandbox: vi.fn(() => ({
+    load: vi.fn(async () => ({ container: render(<SandboxPage />).container })),
+    close: vi.fn(),
+  })),
+}));
+
+describe("Sandbox placeholder text", () => {
+  it("shows the updated placeholder text", async () => {
+    const sandbox = createSandbox();
+    const { container } = await sandbox.load("/sandbox");
+    // check placeholder text
+    const textarea = container.querySelector('textarea');
+    expect(textarea).toHaveAttribute('placeholder', 'Type the changes you want to make...');
+  });
+});

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -73,7 +73,7 @@ export default function SandboxPage() {
                   </MenubarContent>
                 </MenubarMenu>
               </Menubar>
-              <Textarea placeholder="Type the changes you want too make..." />
+              <Textarea placeholder="Type the changes you want to make..." />
               <Menubar>
                 <MenubarMenu>
                   <Button>Files</Button>


### PR DESCRIPTION
## Summary
- correct the placeholder text on projects page
- add regression test checking the placeholder

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a843411688325ab8e98007c4b5ac1