### PR TITLE
Fix client boundary for NavBarHeader

### DIFF
--- a/components/landing-page/header/NavBarHeader.tsx
+++ b/components/landing-page/header/NavBarHeader.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import Link from "next/link";
 import HeaderLogo from "@/components/ui/header-logo";


### PR DESCRIPTION
## Summary
- add `"use client";` directive to NavBarHeader so the component runs on the client

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a84366724832580b7c16979d93d5e