### PR TITLE
Remove deprecated component aliases

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,9 +23,6 @@
     "paths": {
       "@/*": ["./*"],
       "@components/*": ["components/*"],
-      "@atoms/*": ["components/atoms/*"],
-      "@molecules/*": ["components/molecules/*"],
-      "@organisms/*": ["components/landing-page/*"],
       "@genr8/testing-sandbox": ["__mocks__/genr8-testing-sandbox.d.ts"] // ✅ Resolved to match correct declaration file
     }
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,13 +8,6 @@ export default defineConfig({
     alias: {
       "@": fileURLToPath(new URL("./", import.meta.url)),
       "@components": fileURLToPath(new URL("./components", import.meta.url)),
-      "@atoms": fileURLToPath(new URL("./components/atoms", import.meta.url)),
-      "@molecules": fileURLToPath(
-        new URL("./components/molecules", import.meta.url),
-      ),
-      "@organisms": fileURLToPath(
-        new URL("./components/organisms", import.meta.url),
-      ),
       "@genr8/testing-sandbox": fileURLToPath(
         new URL("./__mocks__/genr8-testing-sandbox.ts", import.meta.url),
       ),


### PR DESCRIPTION
## Summary
- remove unused component aliases from `tsconfig.json`
- strip matching aliases from `vitest.config.ts`

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684b86a6d418832583ec41af071f4dab