### PR TITLE
Add landing page layout shell

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,12 @@
 import NavBarHeader from "@/components/landing-page/header/NavBarHeader";
 import KapsulesHero from "@/components/landing-page/hero/kapsules-hero";
+import LandingLayoutShell from "@/components/landing-page/layout/LandingLayoutShell";
 
 export default function HomePage() {
   return (
-    <>
-      <NavBarHeader />
-      <KapsulesHero />
-    </>
+    <LandingLayoutShell
+      header={<NavBarHeader />}
+      hero={<KapsulesHero />}
+    />
   );
 }

--- a/components/landing-page/layout/LandingLayoutShell.tsx
+++ b/components/landing-page/layout/LandingLayoutShell.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { ReactNode } from "react";
+import clsx from "clsx";
+
+interface LandingLayoutShellProps {
+  header?: ReactNode;
+  hero?: ReactNode;
+  className?: string;
+}
+
+export default function LandingLayoutShell({
+  header,
+  hero,
+  className = "",
+}: LandingLayoutShellProps) {
+  return (
+    <div className={clsx("flex flex-col min-h-screen", className)}>
+      {header && <div>{header}</div>}
+      <main className="flex-1 flex flex-col items-center justify-start">
+        {hero}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `LandingLayoutShell` to slot header/hero via props
- wrap landing page in the new layout shell

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684b897e2a388325836f40e7cb5e9474