### PR TITLE
Implement streaming for chat

### DIFF
--- a/components/projects-page/chat/ChatStream.tsx
+++ b/components/projects-page/chat/ChatStream.tsx
@@ -7,8 +7,43 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { useEffect, useRef, useState } from "react";
 
+// Simple representation of a streamed chat message
+type ChatMessage = {
+  id: number;
+  content: string;
+};
+
+/**
+ * Display and auto-scroll streamed chat messages from the AI backend.
+ */
 export default function ChatStream() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const streamRef = useRef<HTMLDivElement>(null);
+
+  // Subscribe to the AI stream once on mount and append incoming messages
+  useEffect(() => {
+    if (typeof window === "undefined" || !("EventSource" in window)) return;
+    const source = new EventSource("/api/chat/stream");
+    source.onmessage = (event) => {
+      setMessages((prev) => [
+        ...prev,
+        { id: prev.length, content: event.data },
+      ]);
+    };
+    return () => {
+      source.close();
+    };
+  }, []);
+
+  // Always scroll to the newest message when messages update
+  useEffect(() => {
+    if (streamRef.current) {
+      streamRef.current.scrollTop = streamRef.current.scrollHeight;
+    }
+  }, [messages]);
+
   return (
     <>
       <Card className="flex flex-1 min-h-[250px] bg-slate-600 p-1 mx-3 my-2 mb-4 border-0">
@@ -21,8 +56,10 @@ export default function ChatStream() {
           </CardHeader>
         </div>
         <div>
-          <CardContent>
-            <CardDescription>*AI RESPONSE GOES HERE*</CardDescription>
+          <CardContent ref={streamRef} className="flex flex-col gap-2">
+            {messages.map((msg) => (
+              <CardDescription key={msg.id}>{msg.content}</CardDescription>
+            ))}
           </CardContent>
         </div>
       </Card>


### PR DESCRIPTION
## Summary
- implement streaming chat logic
- render streamed messages incrementally and auto-scroll

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684b9b9982f08325b20b2cce52cd13a1