### PR TITLE
Add prompt context manager

### DIFF
--- a/__tests__/lib/context-manager.test.ts
+++ b/__tests__/lib/context-manager.test.ts
@@ -1,0 +1,21 @@
+import { addPrompt, getContext, clearContext } from "@/lib/context-manager";
+
+describe("context manager", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("stores prompts per project", () => {
+    addPrompt("a", "first");
+    addPrompt("a", "second");
+    addPrompt("b", "other");
+    expect(getContext("a")).toEqual(["first", "second"]);
+    expect(getContext("b")).toEqual(["other"]);
+  });
+
+  it("clears stored prompts", () => {
+    addPrompt("a", "one");
+    clearContext("a");
+    expect(getContext("a")).toEqual([]);
+  });
+});

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Minimal handler accepting a user prompt and context.
+ * Currently echoes the received data for development purposes.
+ */
+export async function POST(request: NextRequest) {
+  const { prompt, context } = await request.json();
+  console.log("Prompt received", prompt, context);
+  return NextResponse.json({ ok: true });
+}

--- a/components/projects-page/chat/ChatInput.tsx
+++ b/components/projects-page/chat/ChatInput.tsx
@@ -1,15 +1,37 @@
 "use client";
+import { useState } from "react";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
+import { addPrompt, getContext } from "@/lib/context-manager";
 
 export default function ChatInput() {
+  const [text, setText] = useState("");
+  const projectId = "default";
+
+  const handleSend = async () => {
+    if (!text.trim()) return;
+    addPrompt(projectId, text);
+    await fetch("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: text, context: getContext(projectId) }),
+    }).catch(() => {
+      /* ignore network errors for now */
+    });
+    setText("");
+  };
+
   return (
     <div className="flex gap-3 pb-3 ml-1">
       <Textarea
         className=" justify-self-center border-none resize-none outline-none max-w-[90%]"
         placeholder="Type the changes you want to make..."
+        value={text}
+        onChange={(e) => setText(e.target.value)}
       />
-      <Button type="submit">SEND</Button>
+      <Button type="button" onClick={handleSend}>
+        SEND
+      </Button>
     </div>
   );
 }

--- a/components/projects-page/chat/ChatStream.tsx
+++ b/components/projects-page/chat/ChatStream.tsx
@@ -21,11 +21,12 @@ type ChatMessage = {
 export default function ChatStream() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const streamRef = useRef<HTMLDivElement>(null);
+  const projectId = "default";
 
   // Subscribe to the AI stream once on mount and append incoming messages
   useEffect(() => {
     if (typeof window === "undefined" || !("EventSource" in window)) return;
-    const source = new EventSource("/api/chat/stream");
+    const source = new EventSource(`/api/chat/stream?projectId=${projectId}`);
     source.onmessage = (event) => {
       setMessages((prev) => [
         ...prev,
@@ -35,7 +36,7 @@ export default function ChatStream() {
     return () => {
       source.close();
     };
-  }, []);
+  }, [projectId]);
 
   // Always scroll to the newest message when messages update
   useEffect(() => {

--- a/lib/context-manager.ts
+++ b/lib/context-manager.ts
@@ -1,0 +1,58 @@
+// Utility for managing prompt history per project using localStorage
+
+const STORAGE_KEY = "kapped-prompts";
+
+/** Record of prompts for each project ID */
+type PromptHistory = Record<string, string[]>;
+
+/** Load prompt history from localStorage */
+function loadHistory(): PromptHistory {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as PromptHistory) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Persist prompt history back to localStorage */
+function saveHistory(history: PromptHistory): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+  } catch {
+    // Ignore persistence errors
+  }
+}
+
+/**
+ * Add a prompt entry for a given project.
+ * @param projectId Unique ID of the project
+ * @param prompt User prompt text
+ */
+export function addPrompt(projectId: string, prompt: string): void {
+  const history = loadHistory();
+  history[projectId] = [...(history[projectId] || []), prompt];
+  saveHistory(history);
+}
+
+/**
+ * Retrieve stored prompts for a project.
+ * @param projectId Unique ID of the project
+ * @returns Array of prompts or an empty array
+ */
+export function getContext(projectId: string): string[] {
+  const history = loadHistory();
+  return history[projectId] || [];
+}
+
+/**
+ * Remove all stored prompts for a project.
+ * @param projectId Unique ID of the project
+ */
+export function clearContext(projectId: string): void {
+  const history = loadHistory();
+  delete history[projectId];
+  saveHistory(history);
+}


### PR DESCRIPTION
## Summary
- store prompt history per project in new `context-manager` module
- capture prompts from chat UI and send with context to backend
- forward project ID to chat stream
- implement placeholder chat API route
- test context manager behavior

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684b9e8235bc8325bf30d3fcbf61058d