### PR TITLE
Implement chat streaming and toolbar actions

### DIFF
--- a/__tests__/integration/chat-stream-route.test.ts
+++ b/__tests__/integration/chat-stream-route.test.ts
@@ -1,0 +1,29 @@
+import { GET } from "@/app/api/chat/stream/route";
+import { NextRequest } from "next/server";
+
+describe("chat stream route", () => {
+  it("streams messages", async () => {
+    const req = new NextRequest("http://localhost/api/chat/stream");
+    const res = await GET(req);
+
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+
+    const reader = res.body?.getReader();
+    expect(reader).toBeDefined();
+
+    const decoder = new TextDecoder();
+    let text = "";
+
+    if (reader) {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        text += decoder.decode(value);
+      }
+    }
+
+    expect(text).toContain("update 1");
+    expect(text).toContain("update 2");
+    expect(text).toContain("update 3");
+  });
+});

--- a/__tests__/integration/chat-toolbar.test.tsx
+++ b/__tests__/integration/chat-toolbar.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ChatToolbar from "@/components/projects-page/chat/ChatToolbar";
+import { vi } from "vitest";
+
+describe("ChatToolbar", () => {
+  it("triggers action handlers on click", async () => {
+    const user = userEvent.setup();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    render(<ChatToolbar />);
+
+    await user.click(screen.getByText("Files"));
+    await user.click(screen.getByText("Images"));
+    await user.click(screen.getByText("Gen"));
+    await user.click(screen.getByText("Fix"));
+
+    expect(logSpy).toHaveBeenCalledWith("open file picker");
+    expect(logSpy).toHaveBeenCalledWith("upload image");
+    expect(logSpy).toHaveBeenCalledWith("generate code");
+    expect(logSpy).toHaveBeenCalledWith("run fix");
+
+    logSpy.mockRestore();
+  });
+});

--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from "next/server";
+
+/**
+ * SSE endpoint emitting placeholder chat updates for a project.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const projectId = searchParams.get("projectId") || "default";
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      for (let i = 1; i <= 3; i++) {
+        controller.enqueue(
+          encoder.encode(`data: update ${i} for ${projectId}\n\n`),
+        );
+        await new Promise((r) => setTimeout(r, 10));
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/components/projects-page/chat/ChatInput.tsx
+++ b/components/projects-page/chat/ChatInput.tsx
@@ -18,6 +18,17 @@ export default function ChatInput() {
     }).catch(() => {
       /* ignore network errors for now */
     });
+
+    if (typeof window !== "undefined" && "EventSource" in window) {
+      const source = new EventSource(`/api/chat/stream?projectId=${projectId}`);
+      source.onmessage = (e) => {
+        console.log("stream", e.data);
+      };
+      source.onerror = () => {
+        source.close();
+      };
+    }
+
     setText("");
   };
 

--- a/components/projects-page/chat/ChatToolbar.tsx
+++ b/components/projects-page/chat/ChatToolbar.tsx
@@ -9,6 +9,23 @@ import {
 } from "@/components/ui/menubar";
 import { Button } from "@/components/ui/button";
 
+/** Handlers for toolbar actions */
+function openFilePicker() {
+  console.log("open file picker");
+}
+
+function uploadImage() {
+  console.log("upload image");
+}
+
+function generateCode() {
+  console.log("generate code");
+}
+
+function runFix() {
+  console.log("run fix");
+}
+
 export default function ChatToolbar() {
   return (
     <div className="flex flex-1 justify-center items-center mb-1 my-4">
@@ -17,10 +34,30 @@ export default function ChatToolbar() {
           <MenubarTrigger className="py-2 mb-3 text-white hover:bg-gray-700">
             Models
           </MenubarTrigger>
-          <Button className="py-2 mb-3 text-white hover:bg-gray-700">Files</Button>
-          <Button className="py-2 mb-3 text-white hover:bg-gray-700">Images</Button>
-          <Button className="py-2 mb-3 text-white hover:bg-gray-700">Gen</Button>
-          <Button className="py-2 mb-3 text-white hover:bg-gray-700">Fix</Button>
+          <Button
+            className="py-2 mb-3 text-white hover:bg-gray-700"
+            onClick={openFilePicker}
+          >
+            Files
+          </Button>
+          <Button
+            className="py-2 mb-3 text-white hover:bg-gray-700"
+            onClick={uploadImage}
+          >
+            Images
+          </Button>
+          <Button
+            className="py-2 mb-3 text-white hover:bg-gray-700"
+            onClick={generateCode}
+          >
+            Gen
+          </Button>
+          <Button
+            className="py-2 mb-3 text-white hover:bg-gray-700"
+            onClick={runFix}
+          >
+            Fix
+          </Button>
           <MenubarContent>
             <MenubarItem>GPT-4o</MenubarItem>
             <MenubarItem>GPT-4o-mini</MenubarItem>


### PR DESCRIPTION
## Summary
- add `/api/chat/stream` SSE endpoint
- hook up SSE handling in `ChatInput`
- wire up `ChatToolbar` buttons with action handlers
- test toolbar actions
- test chat stream endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ba361c0c48325ae2b97d4b86033d0