### PR TITLE
Add chat streaming API and toolbar handlers

### DIFF
--- a/__tests__/integration/chat-stream-endpoint.test.ts
+++ b/__tests__/integration/chat-stream-endpoint.test.ts
@@ -1,0 +1,19 @@
+import { GET, POST } from "@/app/api/chat/stream/route";
+
+const decoder = new TextDecoder();
+
+describe("chat streaming endpoint", () => {
+  it("emits data to SSE listeners", async () => {
+    const getResponse = GET(new Request("http://localhost/api/chat/stream?projectId=test"));
+    const reader = getResponse.body!.getReader();
+    await POST(
+      new Request("http://localhost/api/chat/stream", {
+        method: "POST",
+        body: JSON.stringify({ projectId: "test", prompt: "hello" }),
+      }),
+    );
+    const { value } = await reader.read();
+    const text = decoder.decode(value);
+    expect(text).toContain("hello");
+  });
+});

--- a/__tests__/integration/chat-toolbar.test.tsx
+++ b/__tests__/integration/chat-toolbar.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ChatToolbar from "@/components/projects-page/chat/ChatToolbar";
+import { vi } from "vitest";
+
+describe("ChatToolbar handlers", () => {
+  it("calls provided callbacks", async () => {
+    const handlers = {
+      onOpenFiles: vi.fn(),
+      onUploadImage: vi.fn(),
+      onGenerate: vi.fn(),
+      onFix: vi.fn(),
+    };
+    const user = userEvent.setup();
+    render(<ChatToolbar {...handlers} />);
+    await user.click(screen.getByRole("button", { name: /files/i }));
+    await user.click(screen.getByRole("button", { name: /images/i }));
+    await user.click(screen.getByRole("button", { name: /gen/i }));
+    await user.click(screen.getByRole("button", { name: /fix/i }));
+    expect(handlers.onOpenFiles).toHaveBeenCalled();
+    expect(handlers.onUploadImage).toHaveBeenCalled();
+    expect(handlers.onGenerate).toHaveBeenCalled();
+    expect(handlers.onFix).toHaveBeenCalled();
+  });
+});

--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest } from "next/server";
+
+// Map to hold SSE listeners per project
+const listeners: Map<string, Set<(data: string) => void>> = new Map();
+
+function broadcast(projectId: string, message: string) {
+  const set = listeners.get(projectId);
+  if (set) {
+    for (const send of set) send(message);
+  }
+}
+
+/** Handle SSE GET requests and maintain connection listeners. */
+export function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const projectId = searchParams.get("projectId") || "default";
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const send = (msg: string) => {
+        controller.enqueue(encoder.encode(`data: ${msg}\n\n`));
+      };
+      const set = listeners.get(projectId) || new Set();
+      set.add(send);
+      listeners.set(projectId, set);
+      return () => {
+        set.delete(send);
+      };
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+/** Broadcast prompt and echo back via SSE */
+export async function POST(req: NextRequest) {
+  const { prompt, projectId = "default" } = await req.json();
+  broadcast(projectId, prompt);
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(`data: ${prompt}\n\n`));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/components/projects-page/chat/ChatInput.tsx
+++ b/components/projects-page/chat/ChatInput.tsx
@@ -11,13 +11,22 @@ export default function ChatInput() {
   const handleSend = async () => {
     if (!text.trim()) return;
     addPrompt(projectId, text);
-    await fetch("/api/chat", {
+    const response = await fetch("/api/chat/stream", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ prompt: text, context: getContext(projectId) }),
+      body: JSON.stringify({ prompt: text, context: getContext(projectId), projectId }),
     }).catch(() => {
       /* ignore network errors for now */
     });
+    if (response && response.body) {
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      // Drain streamed response once for demo purposes
+      await reader.read().then(({ value }) => {
+        if (value) console.log(decoder.decode(value));
+      });
+      reader.releaseLock();
+    }
     setText("");
   };
 

--- a/components/projects-page/chat/ChatToolbar.tsx
+++ b/components/projects-page/chat/ChatToolbar.tsx
@@ -9,7 +9,18 @@ import {
 } from "@/components/ui/menubar";
 import { Button } from "@/components/ui/button";
 
-export default function ChatToolbar() {
+export type ChatToolbarProps = {
+  onOpenFiles?: () => void;
+  onUploadImage?: () => void;
+  onGenerate?: () => void;
+  onFix?: () => void;
+};
+export default function ChatToolbar({
+  onOpenFiles,
+  onUploadImage,
+  onGenerate,
+  onFix,
+}: ChatToolbarProps = {}) {
   return (
     <div className="flex flex-1 justify-center items-center mb-1 my-4">
       <Menubar className="bg-inherit border-none gap-9 mr-4">
@@ -17,10 +28,30 @@ export default function ChatToolbar() {
           <MenubarTrigger className="py-2 mb-3 text-white hover:bg-gray-700">
             Models
           </MenubarTrigger>
-          <Button className="py-2 mb-3 text-white hover:bg-gray-700">Files</Button>
-          <Button className="py-2 mb-3 text-white hover:bg-gray-700">Images</Button>
-          <Button className="py-2 mb-3 text-white hover:bg-gray-700">Gen</Button>
-          <Button className="py-2 mb-3 text-white hover:bg-gray-700">Fix</Button>
+          <Button
+            className="py-2 mb-3 text-white hover:bg-gray-700"
+            onClick={onOpenFiles}
+          >
+            Files
+          </Button>
+          <Button
+            className="py-2 mb-3 text-white hover:bg-gray-700"
+            onClick={onUploadImage}
+          >
+            Images
+          </Button>
+          <Button
+            className="py-2 mb-3 text-white hover:bg-gray-700"
+            onClick={onGenerate}
+          >
+            Gen
+          </Button>
+          <Button
+            className="py-2 mb-3 text-white hover:bg-gray-700"
+            onClick={onFix}
+          >
+            Fix
+          </Button>
           <MenubarContent>
             <MenubarItem>GPT-4o</MenubarItem>
             <MenubarItem>GPT-4o-mini</MenubarItem>


### PR DESCRIPTION
## Summary
- implement `/api/chat/stream` for SSE chat updates
- hook `ChatInput` up to the new streaming endpoint
- add callbacks to `ChatToolbar` buttons
- test chat streaming and toolbar handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ba483cc848325a163e39dddfd89b3