### PR TITLE
Add simple auth flow with Cloudflare KV style store

### DIFF
--- a/__tests__/integration/auth-flow.test.ts
+++ b/__tests__/integration/auth-flow.test.ts
@@ -1,0 +1,23 @@
+import { POST, GET } from "@/app/api/auth/[...nextauth]/route";
+import { NextRequest } from "next/server";
+
+describe("auth flow", () => {
+  it("login redirects and persists session", async () => {
+    const loginReq = new NextRequest("http://localhost/api/auth", {
+      method: "POST",
+      body: JSON.stringify({ email: "user@example.com", password: "pw", action: "signup" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const loginRes = await POST(loginReq);
+    expect(loginRes.status).toBe(302);
+    const cookie = loginRes.headers.get("set-cookie") || "";
+    const token = cookie.match(/session-token=([^;]+)/)?.[1];
+    expect(token).toBeDefined();
+
+    const sessionReq = new NextRequest("http://localhost/api/auth");
+    if (token) sessionReq.cookies.set("session-token", token);
+    const sessionRes = await GET(sessionReq);
+    const data = await sessionRes.json();
+    expect(data.user.email).toBe("user@example.com");
+  });
+});

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  createUser,
+  validateUser,
+  createSession,
+  getSession,
+} from "@/lib/auth-store";
+
+/**
+ * Combined login and session handler.
+ * POST handles login or signup and sets a session cookie.
+ * GET returns the current session from the KV-backed store.
+ */
+export async function POST(request: NextRequest) {
+  const { email, password, action } = await request.json();
+  if (action === "signup") {
+    await createUser(email, password);
+  }
+  const valid = await validateUser(email, password);
+  if (!valid) {
+    return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+  }
+  const token = await createSession(email);
+  const res = NextResponse.redirect(new URL("/projects", request.url), 302);
+  res.cookies.set("session-token", token, { path: "/" });
+  return res;
+}
+
+export async function GET(request: NextRequest) {
+  const token = request.cookies.get("session-token")?.value;
+  if (!token) return NextResponse.json({ user: null });
+  const session = await getSession(token);
+  if (!session) return NextResponse.json({ user: null });
+  return NextResponse.json({ user: { email: session.email } });
+}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+/** Basic login form posting credentials to the auth API */
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        const res = await fetch("/api/auth/[...nextauth]", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email, password }),
+        });
+        if (res.redirected) router.push(res.url);
+      }}
+      className="flex flex-col gap-2 max-w-sm mx-auto mt-10"
+    >
+      <input
+        className="border p-2"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        className="border p-2"
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit" className="bg-black text-white p-2">
+        Login
+      </button>
+    </form>
+  );
+}

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+/** Signup form that triggers user creation via the auth API */
+export default function SignupPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        const res = await fetch("/api/auth/[...nextauth]", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email, password, action: "signup" }),
+        });
+        if (res.redirected) router.push(res.url);
+      }}
+      className="flex flex-col gap-2 max-w-sm mx-auto mt-10"
+    >
+      <input
+        className="border p-2"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        className="border p-2"
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit" className="bg-black text-white p-2">
+        Sign Up
+      </button>
+    </form>
+  );
+}

--- a/components/landing-page/header/NavBarHeader.tsx
+++ b/components/landing-page/header/NavBarHeader.tsx
@@ -36,7 +36,10 @@ const NavBarHeader = () => {
       </div>
       <div className="flex items-center gap-2">
         <Button className="size-sm variant-outline text-white bg-black hover:bg-white hover:text-black">
-          <Link href="/login">Login</Link>
+          <Link href="/auth/login">Login</Link>
+        </Button>
+        <Button className="size-sm variant-outline text-white bg-black hover:bg-white hover:text-black">
+          <Link href="/auth/signup">Sign Up</Link>
         </Button>
         <Avatar>
           <AvatarFallback className="text-black">A</AvatarFallback>

--- a/lib/auth-store.ts
+++ b/lib/auth-store.ts
@@ -1,0 +1,42 @@
+import crypto from "crypto";
+
+/**
+ * In-memory store simulating Cloudflare KV for user and session data.
+ * In production this would be replaced with Cloudflare KV bindings.
+ */
+
+type UserRecord = { email: string; password: string };
+type SessionRecord = { email: string };
+
+const USERS = new Map<string, UserRecord>();
+const SESSIONS = new Map<string, SessionRecord>();
+
+/** Create a new user record */
+export async function createUser(email: string, password: string): Promise<void> {
+  USERS.set(email, { email, password });
+}
+
+/** Validate provided credentials against stored users */
+export async function validateUser(
+  email: string,
+  password: string,
+): Promise<boolean> {
+  return USERS.get(email)?.password === password;
+}
+
+/** Store a new session and return the generated token */
+export async function createSession(email: string): Promise<string> {
+  const token = crypto.randomUUID();
+  SESSIONS.set(token, { email });
+  return token;
+}
+
+/** Retrieve a session by token */
+export async function getSession(token: string): Promise<SessionRecord | null> {
+  return SESSIONS.get(token) || null;
+}
+
+/** Remove a session */
+export async function deleteSession(token: string): Promise<void> {
+  SESSIONS.delete(token);
+}


### PR DESCRIPTION
## Summary
- create simple KV-backed auth store
- add auth API route with login & session handling
- implement login and signup pages
- link new auth pages in landing header
- test login redirect and session persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bb586e6248325929fb0cc79616431