### PR TITLE
Implement project creation flow

### DIFF
--- a/__tests__/integration/projects-route.test.ts
+++ b/__tests__/integration/projects-route.test.ts
@@ -1,0 +1,25 @@
+import { POST } from "@/app/api/projects/route";
+import { NextRequest } from "next/server";
+import { vi } from "vitest";
+import { addPrompt } from "@/lib/context-manager";
+
+vi.mock("@/lib/context-manager", () => ({
+  addPrompt: vi.fn(),
+}));
+
+describe("projects API", () => {
+  it("creates project id and stores prompt", async () => {
+    const req = new NextRequest("http://localhost/api/projects", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "hello" }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(typeof data.id).toBe("string");
+    expect(data.id.length).toBeGreaterThan(0);
+    expect(addPrompt).toHaveBeenCalledWith(data.id, "hello");
+  });
+});

--- a/__tests__/integration/search-form.test.tsx
+++ b/__tests__/integration/search-form.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import SearchForm from "@/components/landing-page/prompt/SearchForm";
+
+const push = vi.fn();
+vi.mock("next/navigation", async () => {
+  const actual = await vi.importActual<typeof import("next/navigation")>(
+    "next/navigation",
+  );
+  return { ...actual, useRouter: () => ({ push }) };
+});
+
+describe("SearchForm", () => {
+  it("creates project and navigates", async () => {
+    const user = userEvent.setup();
+    global.fetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ id: "abc123" }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    render(<SearchForm />);
+    const input = screen.getByPlaceholderText(/what would you like to build/i);
+    await user.type(input, "my app");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+    expect(push).toHaveBeenCalledWith("/projects/abc123");
+  });
+});

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { addPrompt } from "@/lib/context-manager";
+
+/**
+ * Creates a new project from an initial prompt.
+ * Accepts POST { prompt: string } and returns { id: string }.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const { prompt } = await request.json();
+    if (typeof prompt !== "string" || !prompt.trim()) {
+      return NextResponse.json({ error: "Invalid prompt" }, { status: 400 });
+    }
+    const id = crypto.randomUUID();
+    addPrompt(id, prompt);
+    return NextResponse.json({ id });
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+}

--- a/components/landing-page/prompt/SearchForm.tsx
+++ b/components/landing-page/prompt/SearchForm.tsx
@@ -1,14 +1,50 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Github, FilePlus, ImageIcon, LayoutTemplate } from "lucide-react";
 
 const SearchForm = () => {
+  const router = useRouter();
+  const [prompt, setPrompt] = useState("");
+
+  /**
+   * Submit handler creating a new project then navigating to it.
+   */
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!prompt.trim()) return;
+
+    try {
+      const res = await fetch("/api/projects", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt }),
+      });
+      if (!res.ok) throw new Error("Failed");
+      const data: { id: string } = await res.json();
+      router.push(`/projects/${data.id}`);
+    } catch {
+      // Swallow errors silently for now
+    }
+  };
+
   return (
-    <div className="flex items-center justify-center bg-white rounded-xl p-2 shadow-lg max-w-3xl w-full mb-6 z-10">
+    <form
+      onSubmit={handleSubmit}
+      className="flex items-center justify-center bg-white rounded-xl p-2 shadow-lg max-w-3xl w-full mb-6 z-10"
+    >
       <div className="grid grid-cols-[auto_1fr_auto] gap-2 border border-gray-300 rounded-lg p-2 bg-gray-50 w-full box-border">
         <div className="flex flex-col gap-2">
-          <button className="bg-neutral-900 text-white border border-neutral-800 p-2 rounded-md text-sm font-semibold flex items-center justify-center w-10 h-10 hover:bg-neutral-800 transition">
+          <button
+            type="button"
+            className="bg-neutral-900 text-white border border-neutral-800 p-2 rounded-md text-sm font-semibold flex items-center justify-center w-10 h-10 hover:bg-neutral-800 transition"
+          >
             <Github size={16} />
           </button>
-          <button className="bg-neutral-900 text-white border border-neutral-800 p-2 rounded-md text-sm font-semibold flex items-center justify-center w-10 h-10 hover:bg-neutral-800 transition">
+          <button
+            type="button"
+            className="bg-neutral-900 text-white border border-neutral-800 p-2 rounded-md text-sm font-semibold flex items-center justify-center w-10 h-10 hover:bg-neutral-800 transition"
+          >
             <LayoutTemplate size={16} />
           </button>
         </div>
@@ -16,17 +52,25 @@ const SearchForm = () => {
           type="text"
           placeholder="What would you like to build?"
           className="col-span-1 px-2 py-2 text-sm border border-gray-300 rounded-md outline-none bg-white font-sans w-full"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
         />
         <div className="flex flex-col gap-2">
-          <button className="bg-neutral-900 text-white border border-neutral-800 p-2 rounded-md text-sm font-semibold flex items-center justify-center w-10 h-10 hover:bg-neutral-800 transition">
+          <button
+            type="button"
+            className="bg-neutral-900 text-white border border-neutral-800 p-2 rounded-md text-sm font-semibold flex items-center justify-center w-10 h-10 hover:bg-neutral-800 transition"
+          >
             <FilePlus size={16} />
           </button>
-          <button className="bg-neutral-900 text-white border border-neutral-800 p-2 rounded-md text-sm font-semibold flex items-center justify-center w-10 h-10 hover:bg-neutral-800 transition">
+          <button
+            type="submit"
+            className="bg-neutral-900 text-white border border-neutral-800 p-2 rounded-md text-sm font-semibold flex items-center justify-center w-10 h-10 hover:bg-neutral-800 transition"
+          >
             <ImageIcon size={16} />
           </button>
         </div>
       </div>
-    </div>
+    </form>
   );
 };
 


### PR DESCRIPTION
## Summary
- add `/api/projects` POST endpoint for creating project IDs
- wire landing page `SearchForm` to call the endpoint and navigate
- test project creation API and SearchForm behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bb5f658d0832580b6b17eb33a88ae