### PR TITLE
Improve project creation endpoint

### DIFF
--- a/__tests__/integration/projects-route.test.ts
+++ b/__tests__/integration/projects-route.test.ts
@@ -2,10 +2,36 @@ import { POST } from "@/app/api/projects/route";
 import { NextRequest } from "next/server";
 import { vi } from "vitest";
 import { addPrompt } from "@/lib/context-manager";
+import {
+  setStorageAdapters,
+  kvGet,
+} from "@/lib/cloudflare-storage";
+import { storeBuild } from "@/lib/build-manager";
 
 vi.mock("@/lib/context-manager", () => ({
   addPrompt: vi.fn(),
 }));
+const kvMap = new Map<string, string>();
+
+vi.mock("@/lib/build-manager", () => ({
+  storeBuild: vi.fn(async (userId: string, projectId: string, version: string) => {
+    const key = `projects/${userId}/${projectId}/${version}.zip`;
+    kvMap.set(`project:${userId}:${projectId}`, key);
+    return key;
+  }),
+}));
+
+beforeAll(() => {
+  setStorageAdapters({
+    kv: {
+      put: async (k, v) => void kvMap.set(k, v),
+      get: async (k) => kvMap.get(k) ?? null,
+      delete: async (k) => void kvMap.delete(k),
+    },
+  });
+});
+
+beforeEach(() => kvMap.clear());
 
 describe("projects API", () => {
   it("creates project id and stores prompt", async () => {
@@ -21,5 +47,21 @@ describe("projects API", () => {
     expect(typeof data.id).toBe("string");
     expect(data.id.length).toBeGreaterThan(0);
     expect(addPrompt).toHaveBeenCalledWith(data.id, "hello");
+    expect(await kvGet(`project:demo-user:${data.id}`)).toBe("");
+  });
+
+  it("optionally triggers first build", async () => {
+    const req = new NextRequest("http://localhost/api/projects", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "hi", build: true }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+    const key = `projects/demo-user/${data.id}/v1.zip`;
+    expect(storeBuild).toHaveBeenCalledWith("demo-user", data.id, "v1");
+    expect(data.buildKey).toBe(key);
+    expect(await kvGet(`project:demo-user:${data.id}`)).toBe(key);
   });
 });

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,19 +1,44 @@
 import { NextRequest, NextResponse } from "next/server";
 import { addPrompt } from "@/lib/context-manager";
+import { kvPut } from "@/lib/cloudflare-storage";
+import { storeBuild } from "@/lib/build-manager";
 
 /**
  * Creates a new project from an initial prompt.
- * Accepts POST { prompt: string } and returns { id: string }.
+ * Accepts POST { prompt: string, build?: boolean }
+ * and returns { id: string, buildKey?: string }.
  */
 export async function POST(request: NextRequest) {
   try {
-    const { prompt } = await request.json();
+    const body = await request.json();
+    const { prompt, build } = body ?? {};
+
     if (typeof prompt !== "string" || !prompt.trim()) {
       return NextResponse.json({ error: "Invalid prompt" }, { status: 400 });
     }
+    if (build !== undefined && typeof build !== "boolean") {
+      return NextResponse.json({ error: "Invalid build flag" }, { status: 400 });
+    }
+
+    const userId = "demo-user";
     const id = crypto.randomUUID();
+
+    // Track initial prompt in local context
     addPrompt(id, prompt);
-    return NextResponse.json({ id });
+
+    // Create empty project entry
+    await kvPut(`project:${userId}:${id}`, "");
+
+    let buildKey: string | undefined;
+    if (build) {
+      try {
+        buildKey = await storeBuild(userId, id, "v1");
+      } catch {
+        return NextResponse.json({ error: "Build failed" }, { status: 500 });
+      }
+    }
+
+    return NextResponse.json(buildKey ? { id, buildKey } : { id });
   } catch {
     return NextResponse.json({ error: "Invalid request" }, { status: 400 });
   }


### PR DESCRIPTION
## Summary
- extend projects API to write an entry to Cloudflare KV and kick off optional build
- validate incoming project creation requests
- test project creation including KV writes and optional build

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bfec4d9f88325b3457e345d2b7b93