### PR TITLE
Finalize authentication flow

### DIFF
--- a/__tests__/lib/auth-store.test.ts
+++ b/__tests__/lib/auth-store.test.ts
@@ -1,0 +1,24 @@
+import { setStorageAdapters } from "@/lib/cloudflare-storage";
+import { createSession, getSession } from "@/lib/auth-store";
+
+describe("auth-store persistence", () => {
+  const kvMap = new Map<string, string>();
+
+  beforeEach(() => {
+    setStorageAdapters({
+      kv: {
+        put: async (k, v) => void kvMap.set(k, v),
+        get: async (k) => kvMap.get(k) ?? null,
+        delete: async (k) => void kvMap.delete(k),
+      },
+    });
+    kvMap.clear();
+  });
+
+  it("persists sessions to KV", async () => {
+    const token = await createSession("user@example.com");
+    expect(kvMap.has(`sessions:${token}`)).toBe(true);
+    const session = await getSession(token);
+    expect(session?.email).toBe("user@example.com");
+  });
+});

--- a/__tests__/lib/cloudflare-storage.test.ts
+++ b/__tests__/lib/cloudflare-storage.test.ts
@@ -12,7 +12,10 @@ describe("cloudflare storage adapters", () => {
         delete: async (k) => void kvMap.delete(k),
       },
       r2: {
-        put: async (k, d) => void r2Map.set(k, typeof d === "string" ? new TextEncoder().encode(d).buffer : d),
+        put: async (k, d) => {
+          const buffer = typeof d === "string" ? new TextEncoder().encode(d).buffer : d;
+          void r2Map.set(k, buffer as ArrayBuffer);
+        },
         get: async (k) => r2Map.get(k) ?? null,
         delete: async (k) => void r2Map.delete(k),
       },
@@ -30,7 +33,7 @@ describe("cloudflare storage adapters", () => {
 
   it("uploads and fetches from R2", async () => {
     const data = new TextEncoder().encode("zip").buffer;
-    await r2Put("file.zip", data);
+    await r2Put("file.zip", data as ArrayBuffer);
     expect(await r2Get("file.zip")).toEqual(data);
     await r2Delete("file.zip");
     expect(await r2Get("file.zip")).toBeNull();

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -6,6 +6,8 @@ import {
   getSession,
 } from "@/lib/auth-store";
 
+// Session and user records are persisted to Cloudflare KV via auth-store
+
 /**
  * Combined login and session handler.
  * POST handles login or signup and sets a session cookie.

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,42 +1,85 @@
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 /** Basic login form posting credentials to the auth API */
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1, "Password required"),
+});
+
+type FormData = z.infer<typeof schema>;
+
 export default function LoginPage() {
   const router = useRouter();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const form = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (data: FormData) => {
+    setError(null);
+    const res = await fetch("/api/auth/[...nextauth]", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (res.redirected) {
+      router.push(res.url);
+    } else if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error || "Login failed");
+    }
+  };
 
   return (
-    <form
-      onSubmit={async (e) => {
-        e.preventDefault();
-        const res = await fetch("/api/auth/[...nextauth]", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email, password }),
-        });
-        if (res.redirected) router.push(res.url);
-      }}
-      className="flex flex-col gap-2 max-w-sm mx-auto mt-10"
-    >
-      <input
-        className="border p-2"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <input
-        className="border p-2"
-        type="password"
-        placeholder="Password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-      />
-      <button type="submit" className="bg-black text-white p-2">
-        Login
-      </button>
-    </form>
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="flex flex-col gap-4 max-w-sm mx-auto mt-10"
+      >
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="Email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Password</FormLabel>
+              <FormControl>
+                <Input type="password" placeholder="Password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        {error && <p className="text-destructive text-sm">{error}</p>}
+        <Button type="submit" className="w-full">
+          Login
+        </Button>
+      </form>
+    </Form>
   );
 }

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,42 +1,85 @@
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 /** Signup form that triggers user creation via the auth API */
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1, "Password required"),
+});
+
+type FormData = z.infer<typeof schema>;
+
 export default function SignupPage() {
   const router = useRouter();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const form = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (data: FormData) => {
+    setError(null);
+    const res = await fetch("/api/auth/[...nextauth]", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...data, action: "signup" }),
+    });
+    if (res.redirected) {
+      router.push(res.url);
+    } else if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error || "Sign up failed");
+    }
+  };
 
   return (
-    <form
-      onSubmit={async (e) => {
-        e.preventDefault();
-        const res = await fetch("/api/auth/[...nextauth]", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email, password, action: "signup" }),
-        });
-        if (res.redirected) router.push(res.url);
-      }}
-      className="flex flex-col gap-2 max-w-sm mx-auto mt-10"
-    >
-      <input
-        className="border p-2"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <input
-        className="border p-2"
-        type="password"
-        placeholder="Password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-      />
-      <button type="submit" className="bg-black text-white p-2">
-        Sign Up
-      </button>
-    </form>
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="flex flex-col gap-4 max-w-sm mx-auto mt-10"
+      >
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="Email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Password</FormLabel>
+              <FormControl>
+                <Input type="password" placeholder="Password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        {error && <p className="text-destructive text-sm">{error}</p>}
+        <Button type="submit" className="w-full">
+          Sign Up
+        </Button>
+      </form>
+    </Form>
   );
 }

--- a/components/landing-page/navRow/NavRow.tsx
+++ b/components/landing-page/navRow/NavRow.tsx
@@ -1,21 +1,35 @@
+import Link from "next/link";
+
 const navButtons = [
-  "Admin Dashboard",
-  "Landing Page",
-  "AI Chat Interface",
-  "Auth Provider Client",
+  { label: "Admin Dashboard" },
+  { label: "Landing Page" },
+  { label: "AI Chat Interface" },
+  { label: "Auth Provider Client" },
+  { label: "Login", href: "/auth/login" },
+  { label: "Sign Up", href: "/auth/signup" },
 ];
 
 const NavRow = () => {
   return (
     <div className="flex gap-2 flex-wrap justify-center max-w-3xl w-full z-10 mb-2">
-      {navButtons.map((label) => (
-        <button
-          key={label}
-          className="bg-neutral-900 text-white border border-neutral-800 px-4 py-2 rounded-md text-sm font-semibold font-sans cursor-pointer transition hover:bg-neutral-800 whitespace-nowrap flex-shrink-0 z-10"
-        >
-          {label}
-        </button>
-      ))}
+      {navButtons.map(({ label, href }) =>
+        href ? (
+          <Link
+            key={label}
+            href={href}
+            className="bg-neutral-900 text-white border border-neutral-800 px-4 py-2 rounded-md text-sm font-semibold font-sans cursor-pointer transition hover:bg-neutral-800 whitespace-nowrap flex-shrink-0 z-10"
+          >
+            {label}
+          </Link>
+        ) : (
+          <button
+            key={label}
+            className="bg-neutral-900 text-white border border-neutral-800 px-4 py-2 rounded-md text-sm font-semibold font-sans cursor-pointer transition hover:bg-neutral-800 whitespace-nowrap flex-shrink-0 z-10"
+          >
+            {label}
+          </button>
+        ),
+      )}
     </div>
   );
 };

--- a/lib/auth-store.ts
+++ b/lib/auth-store.ts
@@ -1,8 +1,9 @@
 import crypto from "crypto";
+import { kvPut, kvGet, kvDelete } from "./cloudflare-storage";
 
 /**
- * In-memory store simulating Cloudflare KV for user and session data.
- * In production this would be replaced with Cloudflare KV bindings.
+ * In-memory store used as a fallback when Cloudflare KV is not configured.
+ * All operations attempt to persist to KV but gracefully degrade to memory.
  */
 
 type UserRecord = { email: string; password: string };
@@ -14,6 +15,11 @@ const SESSIONS = new Map<string, SessionRecord>();
 /** Create a new user record */
 export async function createUser(email: string, password: string): Promise<void> {
   USERS.set(email, { email, password });
+  try {
+    await kvPut(`users:${email}`, JSON.stringify({ email, password }));
+  } catch {
+    // Ignore if KV isn't configured
+  }
 }
 
 /** Validate provided credentials against stored users */
@@ -21,22 +27,54 @@ export async function validateUser(
   email: string,
   password: string,
 ): Promise<boolean> {
-  return USERS.get(email)?.password === password;
+  const memPassword = USERS.get(email)?.password;
+  if (memPassword !== undefined) {
+    return memPassword === password;
+  }
+  try {
+    const record = await kvGet(`users:${email}`);
+    if (!record) return false;
+    const parsed: UserRecord = JSON.parse(record);
+    USERS.set(email, parsed);
+    return parsed.password === password;
+  } catch {
+    return false;
+  }
 }
 
 /** Store a new session and return the generated token */
 export async function createSession(email: string): Promise<string> {
   const token = crypto.randomUUID();
   SESSIONS.set(token, { email });
+  try {
+    await kvPut(`sessions:${token}`, JSON.stringify({ email }));
+  } catch {
+    // Ignore if KV isn't configured
+  }
   return token;
 }
 
 /** Retrieve a session by token */
 export async function getSession(token: string): Promise<SessionRecord | null> {
-  return SESSIONS.get(token) || null;
+  const mem = SESSIONS.get(token);
+  if (mem) return mem;
+  try {
+    const record = await kvGet(`sessions:${token}`);
+    if (!record) return null;
+    const parsed: SessionRecord = JSON.parse(record);
+    SESSIONS.set(token, parsed);
+    return parsed;
+  } catch {
+    return null;
+  }
 }
 
 /** Remove a session */
 export async function deleteSession(token: string): Promise<void> {
   SESSIONS.delete(token);
+  try {
+    await kvDelete(`sessions:${token}`);
+  } catch {
+    // Ignore if KV isn't configured
+  }
 }

--- a/lib/build-manager.ts
+++ b/lib/build-manager.ts
@@ -19,8 +19,9 @@ export async function storeBuild(
 ): Promise<string> {
   const distDir = join(process.cwd(), "vite-template", "dist");
   const data = await readFile(join(distDir, "index.html"));
+  const buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
   const r2Key = `projects/${userId}/${projectId}/${version}.zip`;
-  await r2Put(r2Key, data);
+  await r2Put(r2Key, buffer);
   await kvPut(`project:${userId}:${projectId}`, r2Key);
   return r2Key;
 }


### PR DESCRIPTION
## Summary
- persist users and sessions in Cloudflare KV
- surface login/signup errors and validate fields
- add login/signup links to landing navigation
- comment auth route behavior
- update build-manager typing
- test auth-store persistence

## Testing
- `npm run lint`
- `npm run test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684bfedbbb74832594ea1007d0cbd87b